### PR TITLE
Change long to float datatype

### DIFF
--- a/Lakeshore372Sup/lakeshore372.db
+++ b/Lakeshore372Sup/lakeshore372.db
@@ -175,7 +175,7 @@ record(ao, "$(P)P:SP") {
   field(SDIS, "$(P)DISABLE")
 }
 
-record(longin, "$(P)I") {
+record(ai, "$(P)I") {
   field(DESC, "PID - integral")
   field(INP, "@lakeshore372.proto getI $(PORT)")
   field(DTYP, "stream")
@@ -190,7 +190,7 @@ record(longin, "$(P)I") {
   field(SDIS, "$(P)DISABLE")
 }
 
-record(longout, "$(P)I:SP") {
+record(ao, "$(P)I:SP") {
   field(DESC, "PID - integral SP")
   field(OUT, "@lakeshore372.proto setI($(P)) $(PORT)")
   field(DTYP, "stream")
@@ -203,7 +203,7 @@ record(longout, "$(P)I:SP") {
   field(SDIS, "$(P)DISABLE")
 }
 
-record(longin, "$(P)D") {
+record(ai, "$(P)D") {
   field(DESC, "PID - derivative")
   field(INP, "@lakeshore372.proto getD $(PORT)")
   field(DTYP, "stream")
@@ -218,7 +218,7 @@ record(longin, "$(P)D") {
   field(SDIS, "$(P)DISABLE")
 }
 
-record(longout, "$(P)D:SP") {
+record(ao, "$(P)D:SP") {
   field(DESC, "PID - derivative SP")
   field(OUT, "@lakeshore372.proto setD($(P)) $(PORT)")
   field(DTYP, "stream")

--- a/Lakeshore372Sup/lakeshore372.proto
+++ b/Lakeshore372Sup/lakeshore372.proto
@@ -43,26 +43,26 @@ getResistance {
 # and since this is an IP device we are unlikely to have bandwidth issues - so use the simpler design.
 getP {
   out "PID? 0";
-  in "%f,%*d,%*d";
+  in "%f,%*f,%*f";
 }
 
 getI {
   out "PID? 0";
-  in "%*f,%d,%*d";
+  in "%*f,%f,%*f";
 }
 
 getD {
   out "PID? 0";
-  in "%*f,%*d,%d";
+  in "%*f,%*f,%f";
 }
 
 setP {
   # Ensure we have up-to-date PID parameters first - otherwise we may send out of date parameters if PID settings
   # are set very quickly (e.g. from a script)
   out "PID? 0";
-  in "%(\$1P)f,%(\$1I)d,%(\$1D)d";
+  in "%(\$1P)f,%(\$1I)f,%(\$1D)f";
   
-  out "PID %f,%(\$1I)d,%(\$1D)d";
+  out "PID %f,%(\$1I)f,%(\$1D)f";
   wait 100;  # Give the device some time to accept the new setpoints.
 }
 
@@ -71,9 +71,9 @@ setI {
   # Ensure we have up-to-date PID parameters first - otherwise we may send out of date parameters if PID settings
   # are set very quickly (e.g. from a script)
   out "PID? 0";
-  in "%(\$1P)f,%(\$1I)d,%(\$1D)d";
+  in "%(\$1P)f,%(\$1I)f,%(\$1D)f";
   
-  out "PID %(\$1P)f,%d,%(\$1D)d";
+  out "PID %(\$1P)f,%f,%(\$1D)f";
   wait 100;  # Give the device some time to accept the new setpoints.
 }
 
@@ -82,8 +82,8 @@ setD {
   # Ensure we have up-to-date PID parameters first - otherwise we may send out of date parameters if PID settings
   # are set very quickly (e.g. from a script)
   out "PID? 0";
-  in "%(\$1P)f,%(\$1I)d,%(\$1D)d";
+  in "%(\$1P)f,%(\$1I)f,%(\$1D)f";
   
-  out "PID %(\$1P)f,%(\$1I)d,%d";
+  out "PID %(\$1P)f,%(\$1I)f,%f";
   wait 100;  # Give the device some time to accept the new setpoints.
 }


### PR DESCRIPTION
The lakeshore 372 required I & D parameters to be integers, however at the protocol level it still expects them to be formatted as floating-point.

The lakeshore does rounding in hardware if the setpoint is not an integer, so it is acceptable to send a float even though it will be rounded